### PR TITLE
🔀 :: (#29) - permission dialog

### DIFF
--- a/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
@@ -29,9 +29,7 @@ class CameraActivity : BaseActivity() {
     override fun init() {
         setContent {
             navController = rememberNavController()
-            navController.addOnDestinationChangedListener { controller, destination, arguments ->
 
-            }
             val showPermissionDialog = remember { mutableStateOf(false) }
 
             val permissionsList = listOfNotNull(

--- a/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
@@ -54,7 +54,7 @@ class CameraActivity : BaseActivity() {
                             showPermissionDialog = showPermissionDialog,
                             context = this@CameraActivity
                         )
-                    }else {
+                    } else {
                         showPermissionDialog.value = false
                         CameraScreen(
                             context = this@CameraActivity

--- a/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/camera/CameraActivity.kt
@@ -1,14 +1,23 @@
 package com.miso.presentation.ui.camera
 
+import android.Manifest
 import android.util.Log
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+import com.google.accompanist.permissions.shouldShowRationale
 import com.miso.presentation.ui.base.BaseActivity
 import com.miso.presentation.ui.camera.screen.CameraScreen
+import com.miso.presentation.ui.util.PermissionHandlerActions
 
 enum class CameraPage(val value: String) {
     Camera("Camera")
@@ -16,20 +25,43 @@ enum class CameraPage(val value: String) {
 
 class CameraActivity : BaseActivity() {
     private lateinit var navController: NavController
+    @OptIn(ExperimentalPermissionsApi::class)
     override fun init() {
         setContent {
             navController = rememberNavController()
             navController.addOnDestinationChangedListener { controller, destination, arguments ->
 
             }
+            val showPermissionDialog = remember { mutableStateOf(false) }
+
+            val permissionsList = listOfNotNull(
+                Manifest.permission.CAMERA
+            )
+            val permissionState = rememberMultiplePermissionsState(permissions = permissionsList)
+
+            LaunchedEffect(key1 = Unit) {
+                if (!permissionState.permissions[0].status.isGranted && !permissionState.permissions[0].status.shouldShowRationale) run {
+                    permissionState.permissions[0].launchPermissionRequest()
+                }
+            }
             NavHost(
                 navController = navController as NavHostController,
                 startDestination = CameraPage.Camera.value
             ) {
                 composable(CameraPage.Camera.name) {
-                    CameraScreen(
-                        context = this@CameraActivity
-                    )
+                    if (!permissionState.permissions[0].status.isGranted) {
+                        showPermissionDialog.value = true
+                        PermissionHandlerActions(
+                            permissionState = permissionState,
+                            showPermissionDialog = showPermissionDialog,
+                            context = this@CameraActivity
+                        )
+                    }else {
+                        showPermissionDialog.value = false
+                        CameraScreen(
+                            context = this@CameraActivity
+                        )
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/miso/presentation/ui/permissiondialog/PermissionDialog.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/permissiondialog/PermissionDialog.kt
@@ -1,0 +1,136 @@
+package com.miso.presentation.ui.permissiondialog
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.miso.design_system.theme.MisoTheme
+import com.miso.presentation.ui.util.PermissionDescriptionProvider
+
+@Composable
+fun PermissionDialog(
+    modifier: Modifier = Modifier,
+    context: Context,
+    permissionDescriptionProvider: PermissionDescriptionProvider,
+    isPermissionPermanentDenial: Boolean,
+    onDismiss: () -> Unit,
+    onOkClick: () -> Unit,
+    onGoToAppSettingsClick: () -> Unit,
+) {
+    Dialog(onDismissRequest = { onDismiss() }) {
+        MisoTheme { colors, typography ->
+            Card(
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier
+                    .size(400.dp, 300.dp)
+                    .padding(top = 5.dp, bottom = 10.dp),
+                elevation = 8.dp
+            ) {
+                Column(modifier = Modifier.background(colors.GREYSCALE1)) {
+                    Column(modifier = Modifier
+                        .background(colors.GREYSCALE1)
+                        .padding(top = 16.dp, bottom = 20.dp)) {
+                        Text(
+                            text = permissionDescriptionProvider.getTitle(context = context),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                            color = colors.WHITE,
+                            style = typography.textMedium,
+                            fontWeight = FontWeight.Normal,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = permissionDescriptionProvider.getDescription(
+                                context = context,
+                                isPermissionPermanentDenial = isPermissionPermanentDenial
+                            ),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(),
+                            color = colors.GREYSCALE2,
+                            style = typography.titleSmall,
+                            fontWeight = FontWeight.Normal,
+                        )
+                    }
+                    Divider(
+                        color = colors.GREYSCALE2,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(0.5.dp)
+                    )
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .background(colors.GREYSCALE1),
+                        horizontalArrangement = Arrangement.SpaceAround,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        TextButton(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .weight(1f),
+                            onClick = {
+                                onDismiss()
+                            }
+                        ) {
+                            Text(
+                                "취소",
+                                color = colors.WHITE,
+                                style = typography.textMedium,
+                                fontWeight = FontWeight.Normal,
+                            )
+                        }
+                        Divider(
+                            color = colors.GREYSCALE2,
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .width(0.5.dp)
+                        )
+                        TextButton(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .weight(1f),
+                            onClick = {
+                                if (isPermissionPermanentDenial) {
+                                    onGoToAppSettingsClick()
+                                } else {
+                                    onOkClick()
+                                }
+                            }
+                        ) {
+                            Text(
+                                "권한 승인",
+                                color = colors.BULE1,
+                                style = typography.textMedium,
+                                fontWeight = FontWeight.Normal,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/miso/presentation/ui/util/PermissionDescriptionProvider.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/util/PermissionDescriptionProvider.kt
@@ -1,0 +1,39 @@
+package com.miso.presentation.ui.util
+
+import android.content.Context
+
+interface PermissionDescriptionProvider {
+    fun getTitle(context: Context): String
+
+    fun getDescription(context: Context, isPermissionPermanentDenial: Boolean): String
+}
+
+class CameraPermissionDescriptionProvider : PermissionDescriptionProvider {
+    override fun getTitle(context: Context): String {
+        return "[필수] 카메라 권한 설정"
+    }
+
+    override fun getDescription(context: Context, isPermissionPermanentDenial: Boolean): String {
+        val description = "MISO가 도움을 드릴수 있게 카메라 권한을 허용해 주세요!"
+        return if(isPermissionPermanentDenial) {
+            "${description}\n${"설정에서 권한을 설정해 주세요."}"
+        } else {
+            description
+        }
+    }
+}
+
+class ReadMediaImagesPermissionDescriptionProvider : PermissionDescriptionProvider {
+    override fun getTitle(context: Context): String {
+        return "[필수] 갤러리 접근 권한 설정"
+    }
+
+    override fun getDescription(context: Context, isPermissionPermanentDenial: Boolean): String {
+        val description = "이미지 등록을 위해 권한을 허용해 주세요!"
+        return if(isPermissionPermanentDenial) {
+            "${description}\n${"설정에서 권한을 설정해 주세요."}"
+        } else {
+            description
+        }
+    }
+}

--- a/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
@@ -13,111 +13,110 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.shouldShowRationale
-import com.miso.design_system.component.dialog.PermissionDialog
+import com.miso.presentation.ui.permissiondialog.PermissionDialog
 
-class PermissionHandler {
-    @OptIn(ExperimentalPermissionsApi::class)
-    @Composable
-    fun PermissionHandlerActions(
-        permissionState: MultiplePermissionsState,
-        showPermissionDialog: MutableState<Boolean>,
-        context: Context
-    ) {
-        if (showPermissionDialog.value){
-            CheckMultiplePermissions(
-                permissionState = permissionState,
-                onPermissionResult = { if (it) showPermissionDialog.value = false },
-                showPermissionDialog = showPermissionDialog,
-                context = context
-            )
-        }
-    }
 
-    @OptIn(ExperimentalPermissionsApi::class)
-    @Composable
-    private fun CheckMultiplePermissions(
-        permissionState: MultiplePermissionsState,
-        onPermissionResult: (Boolean) -> Unit,
-        showPermissionDialog: MutableState<Boolean>,
-        context: Context
-    ) {
-        val permissionDescriptionProviderMap = createPermissionMap()
-
-        when {
-            permissionState.allPermissionsGranted -> {
-                onPermissionResult(true)
-            }
-
-            else -> {
-                onPermissionResult(false)
-                BlockedPermissionDialog(
-                    permissionState = permissionState,
-                    permissionDescriptionProviderMap = permissionDescriptionProviderMap,
-                    context = context,
-                    showPermissionDialog = showPermissionDialog
-                )
-            }
-        }
-
-    }
-
-    private fun createPermissionMap() = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        mapOf(
-            Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
-            Manifest.permission.READ_MEDIA_IMAGES to ReadMediaImagesPermissionDescriptionProvider()
-        )
-    } else {
-        mapOf(
-            Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
-            Manifest.permission.READ_EXTERNAL_STORAGE to ReadMediaImagesPermissionDescriptionProvider()
-        )
-    }
-
-    @OptIn(ExperimentalPermissionsApi::class)
-    @Composable
-    private fun BlockedPermissionDialog(
-        permissionState: MultiplePermissionsState,
-        permissionDescriptionProviderMap: Map<String, PermissionDescriptionProvider>,
-        context: Context,
-        showPermissionDialog: MutableState<Boolean>
-    ) {
-        val blockedPermissionList = permissionState.revokedPermissions.lastOrNull()
-
-        blockedPermissionList?.let {
-            val descriptionProvider =
-                permissionDescriptionProviderMap[it.permission] ?: return@let
-
-            ShowPermissionDialog(
-                permissionState,
-                it.status,
-                descriptionProvider,
-                context,
-                showPermissionDialog
-            )
-        }
-    }
-
-    @OptIn(ExperimentalPermissionsApi::class)
-    @Composable
-    private fun ShowPermissionDialog(
-        permissionState: MultiplePermissionsState,
-        permissionStatus: PermissionStatus,
-        descriptionProvider: PermissionDescriptionProvider,
-        context: Context,
-        showPermissionDialog: MutableState<Boolean>,
-    ) {
-        PermissionDialog(
-            permissionDescriptionProvider = descriptionProvider,
-            isPermissionPermanentDenial = !permissionStatus.shouldShowRationale,
-            onDismiss = { showPermissionDialog.value = false },
-            onOkClick = { permissionState.launchMultiplePermissionRequest() },
-            onGoToAppSettingsClick = {
-                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                    data = Uri.fromParts("package", context.packageName, null)
-                }
-                context.startActivity(intent)
-            },
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun PermissionHandlerActions(
+    permissionState: MultiplePermissionsState,
+    showPermissionDialog: MutableState<Boolean>,
+    context: Context
+) {
+    if (showPermissionDialog.value){
+        CheckMultiplePermissions(
+            permissionState = permissionState,
+            onPermissionResult = { if (it) showPermissionDialog.value = false },
+            showPermissionDialog = showPermissionDialog,
             context = context
         )
     }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun CheckMultiplePermissions(
+    permissionState: MultiplePermissionsState,
+    onPermissionResult: (Boolean) -> Unit,
+    showPermissionDialog: MutableState<Boolean>,
+    context: Context
+) {
+    val permissionDescriptionProviderMap = createPermissionMap()
+
+    when {
+        permissionState.allPermissionsGranted -> {
+            onPermissionResult(true)
+        }
+
+        else -> {
+            onPermissionResult(false)
+            BlockedPermissionDialog(
+                permissionState = permissionState,
+                permissionDescriptionProviderMap = permissionDescriptionProviderMap,
+                context = context,
+                showPermissionDialog = showPermissionDialog
+            )
+        }
+    }
+
+}
+
+private fun createPermissionMap() = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    mapOf(
+        Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
+        Manifest.permission.READ_MEDIA_IMAGES to ReadMediaImagesPermissionDescriptionProvider()
+    )
+} else {
+    mapOf(
+        Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
+        Manifest.permission.READ_EXTERNAL_STORAGE to ReadMediaImagesPermissionDescriptionProvider()
+    )
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun BlockedPermissionDialog(
+    permissionState: MultiplePermissionsState,
+    permissionDescriptionProviderMap: Map<String, PermissionDescriptionProvider>,
+    context: Context,
+    showPermissionDialog: MutableState<Boolean>
+) {
+    val blockedPermissionList = permissionState.revokedPermissions.lastOrNull()
+
+    blockedPermissionList?.let {
+        val descriptionProvider =
+            permissionDescriptionProviderMap[it.permission] ?: return@let
+
+        ShowPermissionDialog(
+            permissionState,
+            it.status,
+            descriptionProvider,
+            context,
+            showPermissionDialog
+        )
+    }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun ShowPermissionDialog(
+    permissionState: MultiplePermissionsState,
+    permissionStatus: PermissionStatus,
+    descriptionProvider: PermissionDescriptionProvider,
+    context: Context,
+    showPermissionDialog: MutableState<Boolean>,
+) {
+    PermissionDialog(
+        permissionDescriptionProvider = descriptionProvider,
+        isPermissionPermanentDenial = !permissionStatus.shouldShowRationale,
+        onDismiss = { showPermissionDialog.value = false },
+        onOkClick = { permissionState.launchMultiplePermissionRequest() },
+        onGoToAppSettingsClick = {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+            }
+            context.startActivity(intent)
+        },
+        context = context
+    )
 }

--- a/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
@@ -1,0 +1,123 @@
+package com.miso.presentation.ui.util
+
+import android.Manifest
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.shouldShowRationale
+import com.miso.design_system.component.dialog.PermissionDialog
+
+class PermissionHandler {
+    @OptIn(ExperimentalPermissionsApi::class)
+    @Composable
+    fun PermissionHandlerActions(
+        permissionState: MultiplePermissionsState,
+        showPermissionDialog: MutableState<Boolean>,
+        context: Context
+    ) {
+        if (showPermissionDialog.value){
+            CheckMultiplePermissions(
+                permissionState = permissionState,
+                onPermissionResult = { if (it) showPermissionDialog.value = false },
+                showPermissionDialog = showPermissionDialog,
+                context = context
+            )
+        }
+    }
+
+    @OptIn(ExperimentalPermissionsApi::class)
+    @Composable
+    private fun CheckMultiplePermissions(
+        permissionState: MultiplePermissionsState,
+        onPermissionResult: (Boolean) -> Unit,
+        showPermissionDialog: MutableState<Boolean>,
+        context: Context
+    ) {
+        val permissionDescriptionProviderMap = createPermissionMap()
+
+        when {
+            permissionState.allPermissionsGranted -> {
+                onPermissionResult(true)
+            }
+
+            else -> {
+                onPermissionResult(false)
+                BlockedPermissionDialog(
+                    permissionState = permissionState,
+                    permissionDescriptionProviderMap = permissionDescriptionProviderMap,
+                    context = context,
+                    showPermissionDialog = showPermissionDialog
+                )
+            }
+        }
+
+    }
+
+    private fun createPermissionMap() = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        mapOf(
+            Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
+            Manifest.permission.READ_MEDIA_IMAGES to ReadMediaImagesPermissionDescriptionProvider()
+        )
+    } else {
+        mapOf(
+            Manifest.permission.CAMERA to CameraPermissionDescriptionProvider(),
+            Manifest.permission.READ_EXTERNAL_STORAGE to ReadMediaImagesPermissionDescriptionProvider()
+        )
+    }
+
+    @OptIn(ExperimentalPermissionsApi::class)
+    @Composable
+    private fun BlockedPermissionDialog(
+        permissionState: MultiplePermissionsState,
+        permissionDescriptionProviderMap: Map<String, PermissionDescriptionProvider>,
+        context: Context,
+        showPermissionDialog: MutableState<Boolean>
+    ) {
+        val blockedPermissionList = permissionState.revokedPermissions.lastOrNull()
+
+        blockedPermissionList?.let {
+            val descriptionProvider =
+                permissionDescriptionProviderMap[it.permission] ?: return@let
+
+            ShowPermissionDialog(
+                permissionState,
+                it.status,
+                descriptionProvider,
+                context,
+                showPermissionDialog
+            )
+        }
+    }
+
+    @OptIn(ExperimentalPermissionsApi::class)
+    @Composable
+    private fun ShowPermissionDialog(
+        permissionState: MultiplePermissionsState,
+        permissionStatus: PermissionStatus,
+        descriptionProvider: PermissionDescriptionProvider,
+        context: Context,
+        showPermissionDialog: MutableState<Boolean>,
+    ) {
+        PermissionDialog(
+            permissionDescriptionProvider = descriptionProvider,
+            isPermanentlyDeclined = !permissionStatus.shouldShowRationale,
+            onDismiss = { showPermissionDialog.value = false },
+            onOkClick = { permissionState.launchMultiplePermissionRequest() },
+            onGoToAppSettingsClick = {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                }
+                context.startActivity(intent)
+            },
+            context = context
+        )
+    }
+}

--- a/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/util/PermissionHandler.kt
@@ -108,7 +108,7 @@ class PermissionHandler {
     ) {
         PermissionDialog(
             permissionDescriptionProvider = descriptionProvider,
-            isPermanentlyDeclined = !permissionStatus.shouldShowRationale,
+            isPermissionPermanentDenial = !permissionStatus.shouldShowRationale,
             onDismiss = { showPermissionDialog.value = false },
             onOkClick = { permissionState.launchMultiplePermissionRequest() },
             onGoToAppSettingsClick = {


### PR DESCRIPTION
## 📌 개요
권한 획득과 거부시 다이얼로그로 재요청

## ✨ 구현 내용
Camera Activity에 권한 획득과 재요청 다이얼로그 로직 추가
PermissionHandler와 PermissionDescriptionProvider 로 dialog 관리

## 📸 구현 영상 (퍼블리싱)

https://github.com/TeamMiso/Miso_Android_v2/assets/108396442/ee5d5e03-d850-44bb-8a14-a528a83c0334


https://github.com/TeamMiso/Miso_Android_v2/assets/108396442/33d806ec-3581-4290-8082-ed4df4936204




