### PR TITLE
🔀 :: (#43) - write the logic search history

### DIFF
--- a/data/src/main/java/com/miso/data/local/datasource/recyclables/LocalRecyclablesDataSource.kt
+++ b/data/src/main/java/com/miso/data/local/datasource/recyclables/LocalRecyclablesDataSource.kt
@@ -1,0 +1,12 @@
+package com.miso.data.local.datasource.recyclables
+
+import com.miso.data.remote.dto.recyclables.response.SearchResponse
+import kotlinx.coroutines.flow.Flow
+
+interface LocalRecyclablesDataSource {
+    suspend fun getSearchHistory(): Flow<List<SearchResponse>>
+
+    suspend fun setSearchHistory(searchHistory: SearchResponse)
+
+    suspend fun removeSearchHistory()
+}

--- a/data/src/main/java/com/miso/data/local/datasource/recyclables/LocalRecyclablesDataSourceImpl.kt
+++ b/data/src/main/java/com/miso/data/local/datasource/recyclables/LocalRecyclablesDataSourceImpl.kt
@@ -1,0 +1,43 @@
+package com.miso.data.local.datasource.recyclables
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.miso.data.local.key.RecyclablesPreferenceKey
+import com.miso.data.remote.dto.recyclables.response.SearchResponse
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class LocalRecyclablesDataSourceImpl @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : LocalRecyclablesDataSource {
+    override suspend fun getSearchHistory(): Flow<List<SearchResponse>> = dataStore.data.map {
+        it[RecyclablesPreferenceKey.SEARCH_HISTORY]?.let { searchHistoryJson ->
+            val type = object : TypeToken<List<SearchResponse>>() {}.type
+            val searchHistoryList = Gson().fromJson<List<SearchResponse>>(searchHistoryJson, type)
+            searchHistoryList ?: emptyList()
+        } ?: run {
+            emptyList()
+        }
+    }
+
+    override suspend fun setSearchHistory(searchHistory: SearchResponse) {
+        dataStore.edit {
+            val currentSearchHistory =
+                it[RecyclablesPreferenceKey.SEARCH_HISTORY]?.let { searchHistoryJson ->
+                    Gson().fromJson(searchHistoryJson, List::class.java) as? MutableList<SearchResponse>
+                } ?: mutableListOf()
+            currentSearchHistory.add(searchHistory)
+            it[RecyclablesPreferenceKey.SEARCH_HISTORY] = Gson().toJson(currentSearchHistory)
+        }
+    }
+
+    override suspend fun removeSearchHistory() {
+        dataStore.edit {
+            it.remove(RecyclablesPreferenceKey.SEARCH_HISTORY)
+        }
+    }
+}

--- a/data/src/main/java/com/miso/data/local/key/AuthPreferenceKey.kt
+++ b/data/src/main/java/com/miso/data/local/key/AuthPreferenceKey.kt
@@ -3,7 +3,6 @@ package com.miso.data.local.key
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object AuthPreferenceKey {
-
     val ACCESS_TOKEN = stringPreferencesKey("access_token")
 
     val ACCESS_TIME = stringPreferencesKey("access_time")

--- a/data/src/main/java/com/miso/data/local/key/RecyclablesPreferenceKey.kt
+++ b/data/src/main/java/com/miso/data/local/key/RecyclablesPreferenceKey.kt
@@ -1,0 +1,7 @@
+package com.miso.data.local.key
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+
+object RecyclablesPreferenceKey {
+    val SEARCH_HISTORY = stringPreferencesKey("search_history")
+}

--- a/data/src/main/java/com/miso/data/repository/RecyclablesRepositoryImpl.kt
+++ b/data/src/main/java/com/miso/data/repository/RecyclablesRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.miso.data.repository
 
+import com.miso.data.local.datasource.recyclables.LocalRecyclablesDataSource
 import com.miso.data.remote.datasource.recyclables.RecyclablesDataSource
+import com.miso.data.remote.dto.recyclables.response.SearchResponse
 import com.miso.data.remote.dto.recyclables.response.toResultModel
 import com.miso.data.remote.dto.recyclables.response.toSearchModel
 import com.miso.domain.model.recyclables.response.ResultResponseModel
@@ -12,6 +14,7 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class RecyclablesRepositoryImpl @Inject constructor(
+    private val localRecyclablesDataSource: LocalRecyclablesDataSource,
     private val remoteRecyclablesDatasource: RecyclablesDataSource
 ): RecyclablesRepository {
     override suspend fun search(search: String): Flow<SearchResponseModel> {
@@ -24,5 +27,22 @@ class RecyclablesRepositoryImpl @Inject constructor(
 
     override suspend fun result(recyclablesType: String): Flow<ResultResponseModel> {
         return remoteRecyclablesDatasource.result(recyclablesType = recyclablesType).map { it.toResultModel() }
+    }
+
+    override suspend fun saveSearchHistory(searchHistory: SearchResponseModel) {
+        searchHistory.let {
+            localRecyclablesDataSource.setSearchHistory(
+                SearchResponse(
+                    title = it.title,
+                    imageUrl = it.imageUrl,
+                    recycleMethod = it.recycleMethod,
+                    recyclablesType = it.recyclablesType
+                )
+            )
+        }
+    }
+
+    override suspend fun getSearchHistory(): Flow<List<SearchResponseModel>> {
+        return localRecyclablesDataSource.getSearchHistory().map { it.map { it.toSearchModel() } }
     }
 }

--- a/di/src/main/java/com/miso/miso_android_v2/module/LocalDataSourceModule.kt
+++ b/di/src/main/java/com/miso/miso_android_v2/module/LocalDataSourceModule.kt
@@ -2,6 +2,8 @@ package com.miso.miso_android_v2.module
 
 import com.miso.data.local.datasource.auth.LocalAuthDataSource
 import com.miso.data.local.datasource.auth.LocalAuthDataSourceImpl
+import com.miso.data.local.datasource.recyclables.LocalRecyclablesDataSource
+import com.miso.data.local.datasource.recyclables.LocalRecyclablesDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,9 @@ abstract class LocalDataSourceModule {
     abstract fun provideLocalAuthDataSource(
         localAuthDataSourceImpl: LocalAuthDataSourceImpl
     ): LocalAuthDataSource
+
+    @Binds
+    abstract fun provideLocalRecyclablesDataSource(
+        localRecyclablesDataSourceImpl: LocalRecyclablesDataSourceImpl
+    ): LocalRecyclablesDataSource
 }

--- a/domain/src/main/java/com/miso/domain/repository/RecyclablesRepository.kt
+++ b/domain/src/main/java/com/miso/domain/repository/RecyclablesRepository.kt
@@ -11,4 +11,8 @@ interface RecyclablesRepository {
     suspend fun searchableList(): Flow<SearchableListResponseModel>
 
     suspend fun result(recyclablesType: String): Flow<ResultResponseModel>
+
+    suspend fun saveSearchHistory(searchHistory: SearchResponseModel)
+
+    suspend fun getSearchHistory(): Flow<List<SearchResponseModel>>
 }

--- a/domain/src/main/java/com/miso/domain/usecase/recyclables/GetSearchHistoryUseCase.kt
+++ b/domain/src/main/java/com/miso/domain/usecase/recyclables/GetSearchHistoryUseCase.kt
@@ -1,0 +1,12 @@
+package com.miso.domain.usecase.recyclables
+
+import com.miso.domain.repository.RecyclablesRepository
+import javax.inject.Inject
+
+class GetSearchHistoryUseCase @Inject constructor(
+    private val recyclablesRepository: RecyclablesRepository
+) {
+    suspend operator fun invoke() = kotlin.runCatching {
+        recyclablesRepository.getSearchHistory()
+    }
+}

--- a/domain/src/main/java/com/miso/domain/usecase/recyclables/SaveSearchHistoryUseCase.kt
+++ b/domain/src/main/java/com/miso/domain/usecase/recyclables/SaveSearchHistoryUseCase.kt
@@ -1,0 +1,13 @@
+package com.miso.domain.usecase.recyclables
+
+import com.miso.domain.model.recyclables.response.SearchResponseModel
+import com.miso.domain.repository.RecyclablesRepository
+import javax.inject.Inject
+
+class SaveSearchHistoryUseCase @Inject constructor(
+    private val recyclablesRepository: RecyclablesRepository
+) {
+    suspend operator fun invoke(searchHistory: SearchResponseModel) = kotlin.runCatching {
+        recyclablesRepository.saveSearchHistory(searchHistory = searchHistory)
+    }
+}

--- a/presentation/src/main/java/com/miso/presentation/ui/search/SearchActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/SearchActivity.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.example.miso.viewmodel.util.Event
 import com.miso.design_system.component.bottombar.MisoBottomNavigationBar
 import com.miso.design_system.theme.MisoTheme
 import com.miso.presentation.ui.base.BaseActivity
@@ -23,6 +24,7 @@ import com.miso.presentation.ui.search.screen.SearchScreen
 import com.miso.presentation.ui.search.screen.SearchableListScreen
 import com.miso.presentation.viewmodel.RecyclablesViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 enum class MainPage(val value: String) {
     Search("Search"),
@@ -42,6 +44,13 @@ class SearchActivity : BaseActivity() {
     private val recyclablesViewModel by viewModels<RecyclablesViewModel>()
 
     override fun init() {
+        lifecycleScope.launch {
+            recyclablesViewModel.resultResponse.collect {
+                if (it is Event.Success) {
+                    recyclablesViewModel.result.value = it.data!!
+                }
+            }
+        }
         setContent {
             val navController = rememberNavController()
             val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -68,7 +77,8 @@ class SearchActivity : BaseActivity() {
                         composable(SubPage.SearchableList.name) {
                             SearchableListScreen(
                                 viewModel = recyclablesViewModel,
-                                onBackClick = { navController.popBackStack() }
+                                onBackClick = { navController.popBackStack() },
+                                onResultClick = { navController.navigate(SubPage.Result.value) }
                             )
                         }
                         composable(SubPage.Result.name) {

--- a/presentation/src/main/java/com/miso/presentation/ui/search/SearchActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/SearchActivity.kt
@@ -47,7 +47,7 @@ class SearchActivity : BaseActivity() {
         lifecycleScope.launch {
             recyclablesViewModel.resultResponse.collect {
                 if (it is Event.Success) {
-                    recyclablesViewModel.result.value = it.data!!
+                    recyclablesViewModel.saveResult(it.data!!)
                 }
             }
         }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
@@ -24,6 +24,7 @@ fun SearchList(
                     title = listItem.title,
                     content = listItem.recycleMethod,
                     image = listItem.imageUrl,
+                    type = listItem.recyclablesType,
                     onItemClick = {}
                 )
                 Spacer(modifier = Modifier.height(32.dp))

--- a/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
@@ -13,7 +13,8 @@ import com.miso.presentation.viewmodel.RecyclablesViewModel
 
 @Composable
 fun SearchList(
-    viewModel: RecyclablesViewModel
+    viewModel: RecyclablesViewModel,
+    onItemClick: (type: String) -> Unit
 ) {
     MisoTheme { _, _ ->
         LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -25,7 +26,7 @@ fun SearchList(
                     content = listItem.recycleMethod,
                     image = listItem.imageUrl,
                     type = listItem.recyclablesType,
-                    onItemClick = {}
+                    onItemClick = { onItemClick(listItem.recyclablesType) }
                 )
                 Spacer(modifier = Modifier.height(32.dp))
             }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchList.kt
@@ -13,22 +13,37 @@ import com.miso.presentation.viewmodel.RecyclablesViewModel
 
 @Composable
 fun SearchList(
+    isSearchHistory: Boolean,
     viewModel: RecyclablesViewModel,
     onItemClick: (type: String) -> Unit
 ) {
     MisoTheme { _, _ ->
         LazyColumn(modifier = Modifier.fillMaxSize()) {
-            items(viewModel.recyclableList.size) { index ->
-                val reversedIndex = viewModel.recyclableList.size - 1 - index
-                val listItem = viewModel.recyclableList[reversedIndex]
-                SearchListItem(
-                    title = listItem.title,
-                    content = listItem.recycleMethod,
-                    image = listItem.imageUrl,
-                    type = listItem.recyclablesType,
-                    onItemClick = { onItemClick(listItem.recyclablesType) }
-                )
-                Spacer(modifier = Modifier.height(32.dp))
+            if (isSearchHistory) {
+                items(viewModel.searchHistory.size) { index ->
+                    val reversedIndex = viewModel.searchHistory.size - 1 - index
+                    val listItem = viewModel.searchHistory[reversedIndex]
+                    SearchListItem(
+                        title = listItem.title,
+                        content = listItem.recycleMethod,
+                        image = listItem.imageUrl,
+                        type = listItem.recyclablesType,
+                        onItemClick = { onItemClick(listItem.recyclablesType) }
+                    )
+                    Spacer(modifier = Modifier.height(32.dp))
+                }
+            } else {
+                items(viewModel.recyclableList.size) { index ->
+                    val listItem = viewModel.recyclableList[index]
+                    SearchListItem(
+                        title = listItem.title,
+                        content = listItem.recycleMethod,
+                        image = listItem.imageUrl,
+                        type = listItem.recyclablesType,
+                        onItemClick = { onItemClick(listItem.recyclablesType) }
+                    )
+                    Spacer(modifier = Modifier.height(32.dp))
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchListItem.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/component/SearchListItem.kt
@@ -33,6 +33,7 @@ fun SearchListItem(
     title: String,
     content: String,
     image: String,
+    type: String,
     onItemClick: () -> Unit
 ) {
     MisoTheme { colors, typography ->
@@ -49,7 +50,7 @@ fun SearchListItem(
         ) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = title,
+                    text = "$title ($type)",
                     style = typography.textSmall,
                     fontWeight = FontWeight.SemiBold,
                     color = colors.GREYSCALE2
@@ -93,6 +94,7 @@ fun ShopProductListItemPreview() {
             title = "안녕하세요",
             content = "그아아ㅏ아ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ아ㅏㅏㅏ아ㅏㅏ아ㅏ아ㅏㅏ아ㅏㅏ아ㅏㅏㅏㅏㅏㅏㅏ아ㅏㅏ아ㅏㅏㅏㅏㅏ아ㅏㅏㅏㅏ아ㅏㅏ아ㅏㅏㅏ아ㅏㅏㅏ아ㅏㅏㅏㅏㅏㅏ아ㅏㅏㅏㄱ",
             image = "https://project-miso.s3.ap-northeast-2.amazonaws.com/file/Rectangle+2083.png",
+            type = "PATE",
             onItemClick = {}
         )
     }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/component/TodayEnvironmentTipComponent.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/component/TodayEnvironmentTipComponent.kt
@@ -1,5 +1,6 @@
 package com.miso.presentation.ui.search.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -39,6 +40,10 @@ fun TodayEnvironmentTipComponent(
                     .border(
                         width = 1.dp,
                         color = colors.PRIMARY,
+                        shape = RoundedCornerShape(999.dp)
+                    )
+                    .background(
+                        color = colors.WHITE,
                         shape = RoundedCornerShape(999.dp)
                     )
                     .padding(start = 16.dp, end = 16.dp)

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
@@ -29,6 +29,7 @@ import com.example.miso.viewmodel.util.Event
 import com.miso.design_system.component.chip.MisoChip
 import com.miso.design_system.component.text.MisoLogoTitleText
 import com.miso.design_system.component.textfield.MisoSearchTextField
+import com.miso.domain.model.recyclables.response.SearchResponseModel
 import com.miso.presentation.ui.search.component.SearchList
 import com.miso.presentation.ui.search.component.SearchListItem
 import com.miso.presentation.ui.search.component.SearchHistoryTitleText
@@ -59,6 +60,18 @@ fun SearchScreen(
 
     LaunchedEffect("Search") {
         search(viewModel = viewModel)
+    }
+
+    LaunchedEffect("SaveSearchHistory") {
+        saveSearchHistory(
+            viewModel = viewModel
+        )
+    }
+
+    LaunchedEffect("GetSearchHistory") {
+        getSearchHistory(
+            viewModel = viewModel
+        )
     }
 
     Box(
@@ -117,17 +130,19 @@ fun SearchScreen(
             Spacer(modifier = Modifier.height(16.dp))
             if (search.isEmpty()) {
                 SearchList(
+                    isSearchHistory = true,
                     viewModel = viewModel,
                     onItemClick = {}
                 )
             } else {
                 SearchListItem(
-                    title = viewModel.title.value,
-                    content = viewModel.recycleMethod.value,
-                    image = viewModel.imageUrl.value,
-                    type = viewModel.recyclablesType.value
+                    title = viewModel.search.value.title,
+                    content = viewModel.search.value.recycleMethod,
+                    image = viewModel.search.value.imageUrl,
+                    type = viewModel.search.value.recyclablesType
                 ) {
-                    viewModel.result(viewModel.recyclablesType.value)
+                    viewModel.saveSearchHistory(viewModel.search.value)
+                    viewModel.result(viewModel.search.value.recyclablesType)
                     onResultClick()
                 }
             }
@@ -146,6 +161,26 @@ suspend fun search(
     viewModel.searchResponse.collect {
         if (it is Event.Success) {
             viewModel.saveSearch(it.data!!)
+        }
+    }
+}
+
+suspend fun saveSearchHistory(
+    viewModel: RecyclablesViewModel
+) {
+    viewModel.saveSearchHistoryResponse.collect {
+        if (it is Event.Success) {
+            viewModel.getSearchHistory()
+        }
+    }
+}
+
+suspend fun getSearchHistory(
+    viewModel: RecyclablesViewModel
+) {
+    viewModel.getSearchHistoryResponse.collect {
+        if (it is Event.Success) {
+            viewModel.saveSearchHistory(it.data!!)
         }
     }
 }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
@@ -68,12 +68,14 @@ fun SearchScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp,)
+            .padding(horizontal = 16.dp)
             .statusBarsPadding()
             .navigationBarsPadding()
     ) {
         Column(
-            modifier = Modifier.pointerInput(Unit) {
+            modifier = Modifier
+                .padding(bottom = 65.dp)
+                .pointerInput(Unit) {
                     detectTapGestures {
                         focusManager.clearFocus()
                     }
@@ -125,7 +127,8 @@ fun SearchScreen(
                 SearchListItem(
                     title = viewModel.title.value,
                     content = viewModel.recycleMethod.value,
-                    image = viewModel.imageUrl.value
+                    image = viewModel.imageUrl.value,
+                    type = viewModel.recyclablesType.value
                 ) {
                     viewModel.result(viewModel.recyclablesType.value)
                     onResultClick()

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
@@ -58,6 +58,12 @@ fun SearchScreen(
 
     var search by remember { mutableStateOf("") }
 
+    LaunchedEffect("Start") {
+        lifecycleScope.launch {
+            viewModel.getSearchHistory()
+        }
+    }
+
     LaunchedEffect("Search") {
         search(viewModel = viewModel)
     }
@@ -132,7 +138,10 @@ fun SearchScreen(
                 SearchList(
                     isSearchHistory = true,
                     viewModel = viewModel,
-                    onItemClick = {}
+                    onItemClick = { type ->
+                        viewModel.result(type)
+                        onResultClick()
+                    }
                 )
             } else {
                 SearchListItem(

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchScreen.kt
@@ -61,10 +61,6 @@ fun SearchScreen(
         search(viewModel = viewModel)
     }
 
-    LaunchedEffect("Result") {
-        result(viewModel = viewModel)
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -121,7 +117,8 @@ fun SearchScreen(
             Spacer(modifier = Modifier.height(16.dp))
             if (search.isEmpty()) {
                 SearchList(
-                    viewModel = viewModel
+                    viewModel = viewModel,
+                    onItemClick = {}
                 )
             } else {
                 SearchListItem(
@@ -149,16 +146,6 @@ suspend fun search(
     viewModel.searchResponse.collect {
         if (it is Event.Success) {
             viewModel.saveSearch(it.data!!)
-        }
-    }
-}
-
-suspend fun result(
-    viewModel: RecyclablesViewModel
-) {
-    viewModel.resultResponse.collect {
-        if (it is Event.Success) {
-            viewModel.saveResult(it.data!!)
         }
     }
 }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchableListScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchableListScreen.kt
@@ -20,6 +20,7 @@ import com.miso.presentation.viewmodel.RecyclablesViewModel
 fun SearchableListScreen(
     viewModel: RecyclablesViewModel,
     onBackClick: () -> Unit,
+    onResultClick: () -> Unit
 ) {
     LaunchedEffect("SearchableList") {
         searchableList(viewModel = viewModel)
@@ -40,7 +41,11 @@ fun SearchableListScreen(
             MisoBlackTitleText(text = "검색 가능한 항목")
             Spacer(modifier = Modifier.height(16.dp))
             SearchList(
-                viewModel = viewModel
+                viewModel = viewModel,
+                onItemClick = { type ->
+                    viewModel.result(type)
+                    onResultClick()
+                }
             )
         }
     }

--- a/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchableListScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/search/screen/SearchableListScreen.kt
@@ -41,6 +41,7 @@ fun SearchableListScreen(
             MisoBlackTitleText(text = "검색 가능한 항목")
             Spacer(modifier = Modifier.height(16.dp))
             SearchList(
+                isSearchHistory = false,
                 viewModel = viewModel,
                 onItemClick = { type ->
                     viewModel.result(type)

--- a/presentation/src/main/java/com/miso/presentation/viewmodel/RecyclablesViewModel.kt
+++ b/presentation/src/main/java/com/miso/presentation/viewmodel/RecyclablesViewModel.kt
@@ -69,6 +69,8 @@ class RecyclablesViewModel @Inject constructor(
         )
     )
         private set
+    var searchHistory = mutableStateListOf<SearchResponseModel>()
+        private set
 
     fun search(search: String) = viewModelScope.launch {
         searchUseCase(search = search)
@@ -143,5 +145,10 @@ class RecyclablesViewModel @Inject constructor(
 
     fun saveResult(data: ResultResponseModel) {
         result.value = data
+    }
+
+    fun saveSearchHistory(data: List<SearchResponseModel>) {
+        searchHistory.clear()
+        searchHistory.addAll(data)
     }
 }

--- a/presentation/src/main/java/com/miso/presentation/viewmodel/RecyclablesViewModel.kt
+++ b/presentation/src/main/java/com/miso/presentation/viewmodel/RecyclablesViewModel.kt
@@ -59,7 +59,6 @@ class RecyclablesViewModel @Inject constructor(
     )
         private set
 
-
     fun search(search: String) = viewModelScope.launch {
         searchUseCase(search = search)
             .onSuccess {


### PR DESCRIPTION
## 📌 개요
- 로직 작성 검색 기록

## ✨ 구현 내용
- 검색 기록 기능 로직 작성
- datastore를 사용해서 검색 기록 로컬에 저장
- 검색 가능 리스트와 검색 기록을 클릭했을때 결과로 이동
