### PR TITLE
🔀 :: (#137) - fix shop detail bug

### DIFF
--- a/presentation/src/main/java/com/miso/presentation/ui/shop/screen/ShopScreen.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/shop/screen/ShopScreen.kt
@@ -66,7 +66,6 @@ fun ShopScreen(
             viewModel = viewModel,
             onItemClick = { id ->
                 viewModel.shopListDetail(id = id)
-                onShopDetailClick()
             }
         )
     }


### PR DESCRIPTION
## 📌 개요
- 상점 상세보기 페이지가 두번 호출됨

## ✨ 구현 내용
- 스크린 호출이 두 번 되어있어서 한 번만 호출되게 수정