### PR TITLE
🔀 :: (#151) - handling sign up exception

### DIFF
--- a/presentation/src/main/java/com/miso/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/miso/presentation/ui/login/LoginActivity.kt
@@ -82,6 +82,7 @@ class LoginActivity : BaseActivity() {
                     SignUpScreen(
                         focusManager = LocalFocusManager.current,
                         onBackClick = { navController.popBackStack() },
+                        viewModel = authViewModel,
                         onVerificationClick = { navController.navigate(LoginPage.Verification.value) },
                         onSignUpClick = { body ->
                             authViewModel.authSignUp(body = body)

--- a/presentation/src/main/java/com/miso/presentation/viewmodel/AuthViewModel.kt
+++ b/presentation/src/main/java/com/miso/presentation/viewmodel/AuthViewModel.kt
@@ -42,6 +42,7 @@ class AuthViewModel @Inject constructor(
     val logoutResponse = _logoutResponse.asStateFlow()
 
     fun authSignUp(body: AuthSignUpRequestModel) = viewModelScope.launch {
+        _authSignUpResponse.value = Event.Loading
         authSignUpUseCase(
             body = body
         ).onSuccess {


### PR DESCRIPTION
## 📌 개요
- 회원가입 예외 핸들링

## ✨ 구현 내용
- 회원가입시 409(이미 가입한 이메일) 예외 처리 및 성공시 화면이 이동하게 변경

## 📸 구현 영상 (퍼블리싱)
[Screen_recording_20240308_112111.webm](https://github.com/TeamMiso/Miso_Android_v2/assets/103114398/f9944e5c-5992-4d1d-b993-51c8312bc86a)
